### PR TITLE
fix: correct input variable name from o2switch_user to o2switch_username

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,7 @@ runs:
       if: ${{ inputs.otp_secret == null }}
       run: |
         URL_ENCODED_PASSWORD=$(echo -n "${{ inputs.o2switch_password }}" | jq -sRr @uri)
-        ENDPOINT='https://${{ inputs.o2switch_user }}:$URL_ENCODED_PASSWORD@${{ inputs.o2switch_host }}:2083/frontend/o2switch/o2switch-ssh-whitelist/index.live.php'
+        ENDPOINT='https://${{ inputs.o2switch_username }}:$URL_ENCODED_PASSWORD@${{ inputs.o2switch_host }}:2083/frontend/o2switch/o2switch-ssh-whitelist/index.live.php'
 
         echo "Get actual whitelisted IPs..."
         UNIQUE_IPS=$(curl -sX GET "$ENDPOINT?r=list" | jq -r '.data.list[] | .address' | sort -u)


### PR DESCRIPTION
### Description
This pull request fixes an issue with the name of an input variable used in the GitHub Action for managing o2switch SSH IP whitelisting.

### What was fixed

- Replaced `inputs.o2switch_user` with the correct `inputs.o2switch_username` to match the defined inputs.

See issue #1 