### PR TITLE
fix: use double quotes for variable interpolation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,7 @@ runs:
       if: ${{ inputs.otp_secret == null }}
       run: |
         URL_ENCODED_PASSWORD=$(echo -n "${{ inputs.o2switch_password }}" | jq -sRr @uri)
-        ENDPOINT='https://${{ inputs.o2switch_username }}:$URL_ENCODED_PASSWORD@${{ inputs.o2switch_host }}:2083/frontend/o2switch/o2switch-ssh-whitelist/index.live.php'
+        ENDPOINT="https://${{ inputs.o2switch_username }}:$URL_ENCODED_PASSWORD@${{ inputs.o2switch_host }}:2083/frontend/o2switch/o2switch-ssh-whitelist/index.live.php"
 
         echo "Get actual whitelisted IPs..."
         UNIQUE_IPS=$(curl -sX GET "$ENDPOINT?r=list" | jq -r '.data.list[] | .address' | sort -u)


### PR DESCRIPTION
### Description
This PR fixes an issue where the `URL_ENCODED_PASSWORD` variable was not being correctly interpolated in the `ENDPOINT` URL due to the use of single quotes.

### What was fixed

- Replaced single quotes with double quotes to correctly interpolate the `URL_ENCODED_PASSWORD` variable in the `ENDPOINT` string.