### PR TITLE
feat: use cPanel SshWhitelist API instead of legacy password logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Add the runner IP in your o2switch whitelist for later remote access.
 
 - Retrieve the runner IP (using [`haythem/public-ip@v1.3`](https://github.com/haythem/public-ip))
-- Uses the o2switch **SshWhitelist API** (via cPanel API Token, no password needed)
+- Uses the `o2switch SshWhitelist API` (via cPanel API Token, no password needed)
 - Supports 2FA
 
 ## Input Options

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Add the runner IP in your o2switch whitelist for later remote access.
 
 - Retrieve the runner IP (using [`haythem/public-ip@v1.3`](https://github.com/haythem/public-ip))
-- URL encode your password
+- Uses the o2switch **SshWhitelist API** (via cPanel API Token, no password needed)
 - Supports 2FA
 
 ## Input Options
@@ -10,15 +10,17 @@ Add the runner IP in your o2switch whitelist for later remote access.
 | Key                 | Required | Default | Description            |
 | ------------------- |--------- | ------- | ---------------------- |
 | `o2switch_username` | `true`   |         | The o2switch username. |
-| `o2switch_password` | `true`   |         | The o2switch password. |
+| `o2switch_api_token`| `true`   |         | The o2switch API token for authentication. |
 | `o2switch_host`     | `true`   |         | The o2switch host.     |
 | `otp_secret`        | `false`  | `null`  | The OTP secret if it is enabled the o2switch account. |
 | `ip_to_keep`        | `false`  | `''`    | The IP to keep in the whitelist. |
 
-### `o2switch_password`
+### `o2switch_api_token`
 
-⚠️ If you don't have 2FA enabled on your o2switch account, then you may know you must URL encode your password.
-Hopefully, this action takes care of this for you, so you can leave your real password in the `o2switch_password` input.
+Provide an API token generated from your o2switch cPanel for authentication.  
+You can create and manage API tokens in your cPanel under "Manage API Tokens".  
+
+For more details, see the [o2switch documentation](https://faq.o2switch.fr/cpanel/securite/token-api-cpanel/).
 
 ## Example workflow
 
@@ -38,7 +40,7 @@ jobs:
         with:
           otp_secret: ${{ secrets.O2SWITCH_OTP_SECRET }}
           o2switch_username: ${{ secrets.O2SWITCH_USER }}
-          o2switch_password: ${{ secrets.O2SWITCH_PASSWORD }}
+          o2switch_api_token: ${{ secrets.O2SWITCH_API_TOKEN }}
           o2switch_host: ${{ secrets.O2SWITCH_HOST }}
 
       # Example deploy step

--- a/action.yml
+++ b/action.yml
@@ -12,11 +12,11 @@ inputs:
   o2switch_username:
     description: 'The o2switch username.'
     required: true
-  o2switch_password:
-    description: 'The o2switch password.'
-    required: true
   o2switch_host:
     description: 'The o2switch host.'
+    required: true
+  o2switch_api_token:
+    description: 'The o2switch API token for authentication.'
     required: true
   ip_to_keep:
     description: 'The IP to keep in the whitelist.'
@@ -41,49 +41,43 @@ runs:
       shell: bash
       if: ${{ inputs.otp_secret != null }}
       run: |
-        ENDPOINT='https://${{ inputs.o2switch_host }}:2083/frontend/o2switch/o2switch-ssh-whitelist/index.live.php'
         OTP=$(oathtool -b --totp '${{ inputs.otp_secret }}')
-        AUTH_STR="Basic $(echo -n '${{ inputs.o2switch_username }}:${{ inputs.o2switch_password }}' | base64)"
+        echo "Remove all whitelisted IPs..."
+        curl -sm 45 -H'Authorization: cpanel ${{ inputs.o2switch_username }}:${{ inputs.o2switch_api_token }}' -H "X-CPANEL-OTP: ${{ inputs.otp_secret }}" \
+          'https://${{ inputs.o2switch_host }}:2083/execute/SshWhitelist/remove_all'
 
-        echo "Get actual whitelisted IPs..."
-        UNIQUE_IPS=$(curl -H "Authorization: $AUTH_STR" -H "X-CPANEL-OTP: $OTP" -sX GET "$ENDPOINT?r=list" | jq -r '.data.list[] | .address' | sort -u)
-        for address in $UNIQUE_IPS; do
-          if [[ $address == "$#{{ inputs.ip_to_keep }}" ]]; then
-              echo "Keep this IP, go to the next..."
-              continue
-          fi
-          echo "Delete this github IP: $address (in & out)"
-          curl -H "Authorization: $AUTH_STR" -H "X-CPANEL-OTP: $OTP" -sX GET "$ENDPOINT?r=remove&address=$address&direction=in&port=22" | jq
-          sleep 3
-          curl -H "Authorization: $AUTH_STR" -H "X-CPANEL-OTP: $OTP" -sX GET "$ENDPOINT?r=remove&address=$address&direction=out&port=22" | jq
-          sleep 3
-        done
-        echo "All non-whitelisted IPs deleted!"
+        echo "Whitelisting the runner IP"
+        curl -sm 45 -H'Authorization: cpanel ${{ inputs.o2switch_username }}:${{ inputs.o2switch_api_token }}' -H "X-CPANEL-OTP: ${{ inputs.otp_secret }}" \
+          'https://${{ inputs.o2switch_host }}:2083/execute/SshWhitelist/add?address=${{ steps.ip.outputs.ipv4 }}&port=22'
 
-        echo "Attempt to whitelist IP..."
-        curl -H "Authorization: $AUTH_STR" -H "X-CPANEL-OTP: $OTP" -sX POST -d 'whitelist[address]=${{ steps.ip.outputs.ipv4 }}' -d 'whitelist[port]=22' "$ENDPOINT?r=add" | jq
+        echo "Checking if the IP is whitelisted..."
+        curl -sm 45 -H'Authorization: cpanel ${{ inputs.o2switch_username }}:${{ inputs.o2switch_api_token }}' -H "X-CPANEL-OTP: ${{ inputs.otp_secret }}" \
+          'https://${{ inputs.o2switch_host }}:2083/execute/SshWhitelist/list' | grep ${{ steps.ip.outputs.ipv4 }}
 
+        echo "Whitelisting the keeping IP if provided..."
+        if [ -n "${{ inputs.ip_to_keep }}" ]; then
+          curl -sm 45 -H'Authorization: cpanel ${{ inputs.o2switch_username }}:${{ inputs.o2switch_api_token }}' -H "X-CPANEL-OTP: ${{ inputs.otp_secret }}" \
+            'https://${{ inputs.o2switch_host }}:2083/execute/SshWhitelist/add?address=${{ inputs.ip_to_keep }}&port=22'
+        fi
+    
     - name: Whitelist IP on hosting & delete github old ones without 2FA
       shell: bash
       if: ${{ inputs.otp_secret == null }}
       run: |
-        URL_ENCODED_PASSWORD=$(echo -n "${{ inputs.o2switch_password }}" | jq -sRr @uri)
-        ENDPOINT="https://${{ inputs.o2switch_username }}:$URL_ENCODED_PASSWORD@${{ inputs.o2switch_host }}:2083/frontend/o2switch/o2switch-ssh-whitelist/index.live.php"
+        echo "Remove all whitelisted IPs..."
+        curl -sm 45 -H'Authorization: cpanel ${{ inputs.o2switch_username }}:${{ inputs.o2switch_api_token }}' \
+          'https://${{ inputs.o2switch_host }}:2083/execute/SshWhitelist/remove_all'
 
-        echo "Get actual whitelisted IPs..."
-        UNIQUE_IPS=$(curl -sX GET "$ENDPOINT?r=list" | jq -r '.data.list[] | .address' | sort -u)
-        for address in $UNIQUE_IPS; do
-          if [[ $address == "$#{{ inputs.ip_to_keep }}" ]]; then
-              echo "Keep this IP, go to the next..."
-              continue
-          fi
-          echo "Delete this github IP: $address (in & out)"
-          curl -sX GET "$ENDPOINT?r=remove&address=$address&direction=in&port=22" | jq
-          sleep 3
-          curl -sX GET "$ENDPOINT?r=remove&address=$address&direction=out&port=22" | jq
-          sleep 3
-        done
-        echo "All non-whitelisted IPs deleted!"
+        echo "Whitelisting the runner IP"
+        curl -sm 45 -H'Authorization: cpanel ${{ inputs.o2switch_username }}:${{ inputs.o2switch_api_token }}' \
+          'https://${{ inputs.o2switch_host }}:2083/execute/SshWhitelist/add?address=${{ steps.ip.outputs.ipv4 }}&port=22'
 
-        echo "Attempt to whitelist IP..."
-        curl -sX POST -d 'whitelist[address]=${{ steps.ip.outputs.ipv4 }}' -d 'whitelist[port]=22' "$ENDPOINT?r=add" | jq
+        echo "Checking if the IP is whitelisted..."
+        curl -sm 45 -H'Authorization: cpanel ${{ inputs.o2switch_username }}:${{ inputs.o2switch_api_token }}' \
+          'https://${{ inputs.o2switch_host }}:2083/execute/SshWhitelist/list' | grep ${{ steps.ip.outputs.ipv4 }}
+
+        echo "Whitelisting the keeping IP if provided..."
+        if [ -n "${{ inputs.ip_to_keep }}" ]; then
+          curl -sm 45 -H'Authorization: cpanel ${{ inputs.o2switch_username }}:${{ inputs.o2switch_api_token }}' \
+            'https://${{ inputs.o2switch_host }}:2083/execute/SshWhitelist/add?address=${{ inputs.ip_to_keep }}&port=22'
+        fi

--- a/action.yml
+++ b/action.yml
@@ -43,20 +43,20 @@ runs:
       run: |
         OTP=$(oathtool -b --totp '${{ inputs.otp_secret }}')
         echo "Remove all whitelisted IPs..."
-        curl -sm 45 -H'Authorization: cpanel ${{ inputs.o2switch_username }}:${{ inputs.o2switch_api_token }}' -H "X-CPANEL-OTP: ${{ inputs.otp_secret }}" \
+        curl -sm 45 -H'Authorization: cpanel ${{ inputs.o2switch_username }}:${{ inputs.o2switch_api_token }}' -H "X-CPANEL-OTP: $OTP" \
           'https://${{ inputs.o2switch_host }}:2083/execute/SshWhitelist/remove_all'
 
         echo "Whitelisting the runner IP"
-        curl -sm 45 -H'Authorization: cpanel ${{ inputs.o2switch_username }}:${{ inputs.o2switch_api_token }}' -H "X-CPANEL-OTP: ${{ inputs.otp_secret }}" \
+        curl -sm 45 -H'Authorization: cpanel ${{ inputs.o2switch_username }}:${{ inputs.o2switch_api_token }}' -H "X-CPANEL-OTP: $OTP" \
           'https://${{ inputs.o2switch_host }}:2083/execute/SshWhitelist/add?address=${{ steps.ip.outputs.ipv4 }}&port=22'
 
         echo "Checking if the IP is whitelisted..."
-        curl -sm 45 -H'Authorization: cpanel ${{ inputs.o2switch_username }}:${{ inputs.o2switch_api_token }}' -H "X-CPANEL-OTP: ${{ inputs.otp_secret }}" \
+        curl -sm 45 -H'Authorization: cpanel ${{ inputs.o2switch_username }}:${{ inputs.o2switch_api_token }}' -H "X-CPANEL-OTP: $OTP" \
           'https://${{ inputs.o2switch_host }}:2083/execute/SshWhitelist/list' | grep ${{ steps.ip.outputs.ipv4 }}
 
         echo "Whitelisting the keeping IP if provided..."
         if [ -n "${{ inputs.ip_to_keep }}" ]; then
-          curl -sm 45 -H'Authorization: cpanel ${{ inputs.o2switch_username }}:${{ inputs.o2switch_api_token }}' -H "X-CPANEL-OTP: ${{ inputs.otp_secret }}" \
+          curl -sm 45 -H'Authorization: cpanel ${{ inputs.o2switch_username }}:${{ inputs.o2switch_api_token }}' -H "X-CPANEL-OTP: $OTP" \
             'https://${{ inputs.o2switch_host }}:2083/execute/SshWhitelist/add?address=${{ inputs.ip_to_keep }}&port=22'
         fi
     


### PR DESCRIPTION
## Summary

This PR refactors the action to use the `o2switch cPanel SshWhitelist API` for IP whitelisting, replacing the previous password-based logic.  
It now requires a `cPanel API token` for authentication and supports `2FA` via an `OTP secret`.

## Credits
https://faq.o2switch.fr/cpanel/outils/exception-parefeu/#exemple-de-cicd-github