### PR TITLE
refactor(action): replace `haythem/public-ip` action with curl ipify

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,10 @@ runs:
   steps:
     - name: Getting runner public IP
       id: ip
-      uses: haythem/public-ip@v1.3
+      shell: bash
+      run: |
+        IPV4=$(curl -s https://api.ipify.org)
+        echo "ipv4=$IPV4" >> $GITHUB_OUTPUT
     
     - name: Installing tools for 2FA
       uses: tecolicom/actions-use-apt-tools@v1


### PR DESCRIPTION
## Summary
This PR replaces the `haythem/public-ip` GitHub Action with a simple Bash script to retrieve the runner’s public IP address using ipify.

The `haythem/public-ip` action currently triggers a deprecation warning in GitHub Actions due to its reliance on Node.js 20 (see screenshot below).

Although the action still works, it is no longer maintained and may become unreliable over time.

Replacing it with a lightweight Bash script removes the dependency on an unmaintained action, eliminates the warning in CI, and simplifies the workflow with a more transparent and reliable approach.

## Deprecation Warning

<img width="982" height="150" alt="image" src="https://github.com/user-attachments/assets/fc0a6bd7-91f9-4562-a6dd-a684dea29c12" />